### PR TITLE
Make availableDeliveryMethods lazy by decomposition

### DIFF
--- a/app/components/delivery-methods.js
+++ b/app/components/delivery-methods.js
@@ -1,14 +1,25 @@
 import Ember from 'ember';
+const { computed } = Ember;
 
 export default Ember.Component.extend({
     store: Ember.inject.service(),
-    availableDeliveryMethods: Ember.computed('deliveryMethods', 'shippingCountry', function() {
-        var shippingCountry = this.get('shippingCountry');
-        var store = this.get('store');
-        return store.filter('deliveryMethod', function(deliveryMethod) {
-            return deliveryMethod.get('shippingCountry') === shippingCountry;
-        })
+
+    deliveryMethods: computed('store', function() {
+        let store = this.get('store');
+
+        return store.find('delivery-method');
     }),
+
+    availableDeliveryMethods: computed(
+        'deliveryMethods.@each.shippingCountry', 'shippingCountry',
+        function() {
+            let deliveryMethods = this.get('deliveryMethods');
+            let shippingCountry = this.get('shippingCountry');
+
+            return deliveryMethods.filterBy('shippingCountry', shippingCountry);
+        }
+    ),
+
     actions : {
         setDeliveryMethod: function(deliveryMethod) {
             this.sendAction('setDeliveryMethod', deliveryMethod)

--- a/app/routes/order.js
+++ b/app/routes/order.js
@@ -27,7 +27,6 @@ export default Ember.Route.extend({
         return order;
     },
     setupController(controller, model) {
-        var deliveryMethods = this.store.find('deliveryMethod');
         controller.set("order", model);
     },
     actions: {


### PR DESCRIPTION
In this one I’ve pulled apart the filtering and fetching into separate computed properties.
