### PR TITLE
Make availableDeliveryMethods lazy with explicit find

### DIFF
--- a/app/components/delivery-methods.js
+++ b/app/components/delivery-methods.js
@@ -5,6 +5,13 @@ export default Ember.Component.extend({
     availableDeliveryMethods: Ember.computed('deliveryMethods', 'shippingCountry', function() {
         var shippingCountry = this.get('shippingCountry');
         var store = this.get('store');
+
+        // store.filter returns a magically auto-updating RecordArray,
+        // but it does *not* fetch records from the API.
+        //
+        // Thus, we need to explicitly trigger the fetch here.
+        store.find('delivery-method');
+
         return store.filter('deliveryMethod', function(deliveryMethod) {
             return deliveryMethod.get('shippingCountry') === shippingCountry;
         })

--- a/app/routes/order.js
+++ b/app/routes/order.js
@@ -27,7 +27,6 @@ export default Ember.Route.extend({
         return order;
     },
     setupController(controller, model) {
-        var deliveryMethods = this.store.find('deliveryMethod');
         controller.set("order", model);
     },
     actions: {


### PR DESCRIPTION
Here we’re just moving where store.find('delivery-method') happens.
